### PR TITLE
Linux下gvim的字体问题

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -237,7 +237,12 @@ nnoremap ; :
 if has("gui_running")
     set go=aAce  " remove toolbar
     "set transparency=30
-    set guifont=Monaco:h13
+    if has("gui_gtk2")
+        set guifont=Monaco\ 13
+    elseif has("gui_win32")
+        set guifont=Monaco:h13
+    elseif has("gui_mac")
+        set guifont=Monaco:h13
     set showtabline=2
     set columns=140
     set lines=40


### PR DESCRIPTION
设置guifont时没加判断，linux下的gvim字体间距会变得很奇怪

linux设置guifont是和win、mac不同的

```
set guifont=Monaco\ 13
```

![window](https://f.cloud.github.com/assets/5170232/943687/d8b277e8-024b-11e3-881d-4b299789a8e4.png)
